### PR TITLE
feat: add verifySSL param

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The `InfisicalSDKClient` takes the following parameters, which are used as a glo
 
 - **host** (`str`, _Optional_): The host URL for your Infisical instance. Defaults to `https://app.infisical.com`.
 - **token** (`str`, _Optional_): Specify an authentication token to use for all requests. If provided, you will not need to call any of the `auth` methods. Defaults to `None`
+- **verifySSL** (`bool`, _Optional_): Whether to run the security certificate check for SSL/TLS connections. Defaults to `True`
 - **cache_ttl** (`int`, _Optional_): The SDK has built-in client-side caching for secrets, greatly improving response times. By default, secrets are cached for 1 minute (60 seconds). You can disable caching by setting `cache_ttl` to `None`, or adjust the duration in seconds as needed.
 
 ```python

--- a/infisical_sdk/client.py
+++ b/infisical_sdk/client.py
@@ -14,6 +14,7 @@ class InfisicalSDKClient:
         :param str host: The host URL for your Infisical instance. Will default to `https://app.infisical.com` if not specified.
         :param str token: The authentication token for the client. If not specified, you can use the `auth` methods to authenticate.
         :param int cache_ttl: The time to live for the secrets cache. This is the number of seconds that secrets fetched from the API will be cached for. Set to `None` to disable caching. Defaults to `60` seconds.
+        :param bool verifySSL: Whether to verify SSL certificates. Set to `False` to disable verification for self-signed certificates. Defaults to `True`.
         """
         
         self.host = host

--- a/infisical_sdk/client.py
+++ b/infisical_sdk/client.py
@@ -7,7 +7,7 @@ from infisical_sdk.resources import KMS
 from infisical_sdk.util import SecretsCache
 
 class InfisicalSDKClient:
-    def __init__(self, host: str, token: str = None, cache_ttl: int = 60):
+    def __init__(self, host: str, token: str = None, cache_ttl: int = 60, verifySSL: bool = True):
         """
         Initialize the Infisical SDK client.
 
@@ -18,8 +18,9 @@ class InfisicalSDKClient:
         
         self.host = host
         self.access_token = token
+        self.verifySSL = verifySSL
 
-        self.api = InfisicalRequests(host=host, token=token)
+        self.api = InfisicalRequests(host=host, token=token, verifySSL=verifySSL)
         self.cache = SecretsCache(cache_ttl)
         self.auth = Auth(self.api, self.set_token)
         self.secrets = V3RawSecrets(self.api, self.cache)

--- a/infisical_sdk/infisical_requests.py
+++ b/infisical_sdk/infisical_requests.py
@@ -51,9 +51,10 @@ class APIResponse(Generic[T]):
 
 
 class InfisicalRequests:
-    def __init__(self, host: str, token: Optional[str] = None):
+    def __init__(self, host: str, token: Optional[str] = None, verifySSL: bool = True):
         self.host = host.rstrip("/")
         self.session = requests.Session()
+        self.verifySSL = verifySSL
 
         # Set common headers
         self.session.headers.update({
@@ -108,7 +109,7 @@ class InfisicalRequests:
             model: model class to parse response into
             params: Optional query parameters
         """
-        response = self.session.get(self._build_url(path), params=params)
+        response = self.session.get(self._build_url(path), params=params, verify=self.verifySSL)
         data = self._handle_response(response)
 
         parsed_data = model.from_dict(data) if hasattr(model, 'from_dict') else data
@@ -132,7 +133,7 @@ class InfisicalRequests:
             # Filter out None values
             json = {k: v for k, v in json.items() if v is not None}
 
-        response = self.session.post(self._build_url(path), json=json)
+        response = self.session.post(self._build_url(path), json=json, verify=self.verifySSL)
         data = self._handle_response(response)
 
         parsed_data = model.from_dict(data) if hasattr(model, 'from_dict') else data
@@ -156,7 +157,7 @@ class InfisicalRequests:
             # Filter out None values
             json = {k: v for k, v in json.items() if v is not None}
 
-        response = self.session.patch(self._build_url(path), json=json)
+        response = self.session.patch(self._build_url(path), json=json, verify=self.verifySSL)
         data = self._handle_response(response)
 
         parsed_data = model.from_dict(data) if hasattr(model, 'from_dict') else data
@@ -180,7 +181,7 @@ class InfisicalRequests:
             # Filter out None values
             json = {k: v for k, v in json.items() if v is not None}
 
-        response = self.session.delete(self._build_url(path), json=json)
+        response = self.session.delete(self._build_url(path), json=json, verify=self.verifySSL)
         data = self._handle_response(response)
 
         parsed_data = model.from_dict(data) if hasattr(model, 'from_dict') else data

--- a/infisical_sdk/infisical_requests.py
+++ b/infisical_sdk/infisical_requests.py
@@ -51,6 +51,16 @@ class APIResponse(Generic[T]):
 
 
 class InfisicalRequests:
+    """
+    Initialize the Infisical requests client.
+    
+    :param str host: The host URL for your Infisical instance.
+    :param str token: Optional authentication token for the client.
+    :param bool verifySSL: Whether to verify SSL certificates. Set to `False` to disable 
+                            verification for self-signed certificates. Warning: Disabling 
+                            SSL verification may expose you to man-in-the-middle attacks.
+                            Only use in development or with trusted networks. Defaults to `True`.
+    """
     def __init__(self, host: str, token: Optional[str] = None, verifySSL: bool = True):
         self.host = host.rstrip("/")
         self.session = requests.Session()
@@ -175,7 +185,7 @@ class InfisicalRequests:
             json: Optional[Dict[str, Any]] = None
           ) -> APIResponse[T]:
 
-        """Make a PATCH request with JSON data"""
+        """Make a DELETE request with JSON data"""
 
         if json is not None:
             # Filter out None values


### PR DESCRIPTION
This PR adds a verifySSL bool parameter to the InfisicalSDKClient so requests to self-hosted servers with self-signed certificates work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional setting to enable or disable SSL certificate verification, allowing enhanced security configuration during API interactions.

- **Documentation**
  - Updated the user guide to include details on the new SSL verification option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->