### PR TITLE
fix: handle missing createdAt/updatedAt keys and support snake_case from backend

### DIFF
--- a/infisical_sdk/api_types.py
+++ b/infisical_sdk/api_types.py
@@ -36,7 +36,13 @@ class BaseModel:
         """Create model from dictionary"""
         # Get only the fields that exist in the dataclass
         valid_fields = {f.name for f in fields(cls)}
-        filtered_data = {k: v for k, v in data.items() if k in valid_fields}
+        # Handle snake_case to camelCase conversion if needed
+        renamed = data.copy()
+        if 'created_at' in renamed:
+            renamed['createdAt'] = renamed.pop('created_at')
+        if 'updated_at' in renamed:
+            renamed['updatedAt'] = renamed.pop('updated_at')
+        filtered_data = {k: v for k, v in renamed.items() if k in valid_fields}
         return cls(**filtered_data)
 
     def to_json(self) -> str:
@@ -71,8 +77,8 @@ class BaseSecret(BaseModel):
     secretKey: str
     secretValue: str
     secretComment: str
-    createdAt: str
-    updatedAt: str
+    createdAt: Optional[str] = None
+    updatedAt: Optional[str] = None
     secretMetadata: Optional[Dict[str, Any]] = None
     secretValueHidden: Optional[bool] = False
     secretReminderNote: Optional[str] = None
@@ -150,8 +156,8 @@ class KmsKey(BaseModel):
     isDisabled: bool
     orgId: str
     name: str
-    createdAt: str
-    updatedAt: str
+    createdAt: Optional[str] = None
+    updatedAt: Optional[str] = None
     projectId: str
     version: int
     encryptionAlgorithm: SymmetricEncryption


### PR DESCRIPTION
Hi there!

I used the methods listed in the docs to import secrets from infisical via the SDK, but I ran into a problem:

Traceback (most recent call last):
File "/app/src/redis_worker/worker.py", line 10, in
from config.secrets_config import get_secret
File "/app/src/config/secrets_config.py", line 28, in
raw = client.secrets.list_secrets(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/infisical_sdk/resources/secrets.py", line 52, in list_secrets
result = self.requests.get(
^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/infisical_sdk/infisical_requests.py", line 88, in wrapper
return func(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/infisical_sdk/infisical_requests.py", line 169, in get
parsed_data = model.from_dict(data) if hasattr(model, 'from_dict') else data
^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/infisical_sdk/api_types.py", line 105, in from_dict
secrets=[BaseSecret.from_dict(secret) for secret in data['secrets']],
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/infisical_sdk/api_types.py", line 40, in from_dict
return cls(**filtered_data)
^^^^^^^^^^^^^^^^^^^^
TypeError: BaseSecret.init() missing 2 required positional arguments: 'createdAt' and 'updatedAt'.


So what was done:

1. Made the `createdate` and `updatedate` fields optional  
    In the `Bazasecret` and `KmsKey` models, these fields are now of type `Optional[str] = None`, meaning they may be missing (there will be `None`).

2. Added processing of different field names ('snake_case' → `camelCase')

3. The `from_dict` method of the base model now includes shifting values from the `created_at` fields. = `created At` and `updated_at` = `updatedAt`  
   - This means that if the response from the API comes in `snake_case` (for example, `created_at`), the data will be converted to `camelCase` inside the model, and the constructor will not crash even if the API returns one of two options.