### PR TITLE
feat(secrets): add sync_env_vars capability to list_secrets

### DIFF
--- a/infisical_sdk/resources/secrets.py
+++ b/infisical_sdk/resources/secrets.py
@@ -1,11 +1,18 @@
-from typing import List, Union, Optional, Dict, Any
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
 
+from infisical_sdk.api_types import (
+    BaseSecret,
+    ListSecretsResponse,
+    SingleSecretResponse,
+)
 from infisical_sdk.infisical_requests import InfisicalRequests
-from infisical_sdk.api_types import ListSecretsResponse, SingleSecretResponse, BaseSecret
 from infisical_sdk.util import SecretsCache
 
 CACHE_KEY_LIST_SECRETS = "cache-list-secrets"
 CACHE_KEY_SINGLE_SECRET = "cache-single-secret"
+
 
 class V3RawSecrets:
     def __init__(self, requests: InfisicalRequests, cache: SecretsCache) -> None:
@@ -13,16 +20,19 @@ class V3RawSecrets:
         self.cache = cache
 
     def list_secrets(
-            self,
-            environment_slug: str,
-            secret_path: str,
-            project_id: str = None,
-            expand_secret_references: bool = True,
-            view_secret_value: bool = True,
-            recursive: bool = False,
-            include_imports: bool = True,
-            tag_filters: List[str] = [],
-            project_slug: str = None) -> ListSecretsResponse:
+        self,
+        environment_slug: str,
+        secret_path: str,
+        project_id: str = None,
+        expand_secret_references: bool = True,
+        view_secret_value: bool = True,
+        recursive: bool = False,
+        include_imports: bool = True,
+        tag_filters: List[str] = [],
+        project_slug: str = None,
+        sync_env_vars: bool = False,
+        env_path: str = ".env",
+    ) -> ListSecretsResponse:
 
         params = {
             "workspaceId": project_id,
@@ -32,7 +42,7 @@ class V3RawSecrets:
             "expandSecretReferences": str(expand_secret_references).lower(),
             "recursive": str(recursive).lower(),
             "include_imports": str(include_imports).lower(),
-            "workspaceSlug": project_slug
+            "workspaceSlug": project_slug,
         }
 
         if project_slug is None and project_id is None:
@@ -41,106 +51,209 @@ class V3RawSecrets:
         if tag_filters:
             params["tagSlugs"] = ",".join(tag_filters)
 
-        
         cache_key = self.cache.compute_cache_key(CACHE_KEY_LIST_SECRETS, **params)
         if self.cache.enabled:
-          cached_response = self.cache.get(cache_key)
+            cached_response = self.cache.get(cache_key)
 
-          if cached_response is not None and isinstance(cached_response, ListSecretsResponse):
-            return cached_response
+            if cached_response is not None and isinstance(
+                cached_response, ListSecretsResponse
+            ):
+                return cached_response
 
         result = self.requests.get(
-            path="/api/v3/secrets/raw",
-            params=params,
-            model=ListSecretsResponse
+            path="/api/v3/secrets/raw", params=params, model=ListSecretsResponse
         )
+        if sync_env_vars:
+            self._perform_sync_and_report(result.data, env_path)
 
         if self.cache.enabled:
-          self.cache.set(cache_key, result.data)
+            self.cache.set(cache_key, result.data)
 
         return result.data
 
+    def _perform_sync_and_report(self, result: ListSecretsResponse, env_path: str):
+        report_path = ".infisical-sync-report.txt"
+        self._ensure_ignored(report_path)
+
+        # 1. Setup Data
+        timestamp = datetime.now().strftime("%Y-%m-%d | %H:%M:%S")
+        added_count = 0
+        updated_count = 0
+        change_logs = []
+
+        # 2. Read the entire .env file (if exists) to maintain order and comments
+        file_lines = []
+        if os.path.exists(env_path):
+            with open(env_path, "r") as f:
+                file_lines = f.readlines()
+
+        # Create a mapping of key to line index for quick updates
+        env_map = {}
+        for idx, line in enumerate(file_lines):
+            clean_line = line.strip()
+            if "=" in clean_line and not clean_line.startswith("#"):
+                k, v = clean_line.split("=", 1)
+                env_map[k.strip()] = {"index": idx, "value": v.strip()}
+
+        added_count = 0
+        updated_count = 0
+        new_entries = []
+
+        # 3. Process API Secrets
+        for secret in result.secrets:
+            key = secret.secretKey
+            api_val = secret.secretValue
+
+            if key in env_map:
+                # Check for conflict
+                if env_map[key]["value"] != api_val:
+                    old_val = env_map[key]["value"]
+                    # Update the line in the original file list
+                    line_index = env_map[key]["index"]
+                    file_lines[line_index] = f"{key}={api_val}\n"
+
+                    change_logs.append(
+                        f"  [UPDATED] {key.ljust(20)} : '{old_val}' -> '{api_val}'"
+                    )
+                    updated_count += 1
+            else:
+                # Key doesn't exist, prepare to append
+                new_entries.append(f"{key}={api_val}\n")
+                change_logs.append(f"  [ADDED]   {key}")
+                added_count += 1
+
+        # 4. Write back to .env
+        # Combine existing (potentially modified) lines with brand new entries
+        with open(env_path, "w") as f:
+            f.writelines(file_lines)
+            if new_entries:
+                if file_lines and not file_lines[-1].endswith("\n"):
+                    f.write("\n")
+                f.writelines(new_entries)
+
+        # 5. Finalize and Write Report
+        report_block = [
+            "\n" + "═" * 60 + "\n",
+            f" 📅 SYNC DATE: {timestamp}\n",
+            f" 📁 TARGET:    {env_path}\n",
+            f" 📥 FETCHED:   {len(result.secrets)} secrets\n",
+            "─" * 60 + "\n",
+        ]
+
+        if not change_logs:
+            report_block.append("  ✨ No changes detected. Local file is up to date.\n")
+        else:
+            report_block.extend([line + "\n" for line in change_logs])
+
+        report_block.extend([
+            "─" * 60 + "\n",
+            f" ✅ SUMMARY:   {added_count} added | {updated_count} updated\n",
+            "═" * 60 + "\n",
+        ])
+
+        with open(report_path, "a") as f:
+            f.writelines(report_block)
+
+    def _ensure_ignored(self, filename: str):
+        """Adds the filename to .gitignore if not already present."""
+
+        gitignore_path = ".gitignore"
+        if not os.path.exists(gitignore_path):
+            with open(gitignore_path, "w") as f:
+                f.write(f"{filename}\n")
+            return
+
+        with open(gitignore_path, "r") as f:
+            lines = f.readlines()
+
+        if not any(filename in line for line in lines):
+            with open(gitignore_path, "a") as f:
+                f.write(f"\n\n# Infisical temporary sync reports\n{filename}\n")
+
     def get_secret_by_name(
-            self,
-            secret_name: str,
-            environment_slug: str,
-            secret_path: str,
-            project_id: str = None,
-            project_slug: str = None,
-            expand_secret_references: bool = True,
-            include_imports: bool = True,
-            view_secret_value: bool = True,
-            version: str = None) -> BaseSecret:
+        self,
+        secret_name: str,
+        environment_slug: str,
+        secret_path: str,
+        project_id: str = None,
+        project_slug: str = None,
+        expand_secret_references: bool = True,
+        include_imports: bool = True,
+        view_secret_value: bool = True,
+        version: str = None,
+    ) -> BaseSecret:
 
         params = {
-          "workspaceId": project_id,
-          "workspaceSlug": project_slug,
-          "viewSecretValue": str(view_secret_value).lower(),
-          "environment": environment_slug,
-          "secretPath": secret_path,
-          "expandSecretReferences": str(expand_secret_references).lower(),
-          "include_imports": str(include_imports).lower(),
-          "version": version
+            "workspaceId": project_id,
+            "workspaceSlug": project_slug,
+            "viewSecretValue": str(view_secret_value).lower(),
+            "environment": environment_slug,
+            "secretPath": secret_path,
+            "expandSecretReferences": str(expand_secret_references).lower(),
+            "include_imports": str(include_imports).lower(),
+            "version": version,
         }
 
         if project_slug is None and project_id is None:
             raise ValueError("project_slug or project_id must be provided")
 
         cache_params = {
-           "project_id": project_id,
-           "environment_slug": environment_slug,
-           "secret_path": secret_path,
-           "secret_name": secret_name,
+            "project_id": project_id,
+            "environment_slug": environment_slug,
+            "secret_path": secret_path,
+            "secret_name": secret_name,
         }
 
-        cache_key = self.cache.compute_cache_key(CACHE_KEY_SINGLE_SECRET, **cache_params)
+        cache_key = self.cache.compute_cache_key(
+            CACHE_KEY_SINGLE_SECRET, **cache_params
+        )
 
         if self.cache.enabled:
-          cached_response = self.cache.get(cache_key)
+            cached_response = self.cache.get(cache_key)
 
-          if cached_response is not None and isinstance(cached_response, BaseSecret):
-            return cached_response
+            if cached_response is not None and isinstance(cached_response, BaseSecret):
+                return cached_response
 
         result = self.requests.get(
             path=f"/api/v3/secrets/raw/{secret_name}",
             params=params,
-            model=SingleSecretResponse
+            model=SingleSecretResponse,
         )
 
         if self.cache.enabled:
-          self.cache.set(cache_key, result.data.secret)
+            self.cache.set(cache_key, result.data.secret)
 
         return result.data.secret
 
     def create_secret_by_name(
-            self,
-            secret_name: str,
-            secret_path: str,
-            environment_slug: str,
-            project_id: str = None,
-            secret_value: str = None,
-            secret_comment: str = None,
-            skip_multiline_encoding: bool = False,
-            secret_reminder_repeat_days: Union[float, int] = None,
-            secret_reminder_note: str = None,
-            project_slug: str = None,
-            secret_metadata: Optional[List[Dict[str, Any]]] = None,
-            tags_ids: Optional[List[str]] = None,
-            ) -> BaseSecret:
+        self,
+        secret_name: str,
+        secret_path: str,
+        environment_slug: str,
+        project_id: str = None,
+        secret_value: str = None,
+        secret_comment: str = None,
+        skip_multiline_encoding: bool = False,
+        secret_reminder_repeat_days: Union[float, int] = None,
+        secret_reminder_note: str = None,
+        project_slug: str = None,
+        secret_metadata: Optional[List[Dict[str, Any]]] = None,
+        tags_ids: Optional[List[str]] = None,
+    ) -> BaseSecret:
 
         requestBody = {
-          "workspaceId": project_id,
-          "projectSlug": project_slug,
-          "environment": environment_slug,
-          "secretPath": secret_path,
-          "secretValue": secret_value,
-          "secretComment": secret_comment,
-          "tagIds": tags_ids,
-          "skipMultilineEncoding": skip_multiline_encoding,
-          "type": "shared",
-          "secretReminderRepeatDays": secret_reminder_repeat_days,
-          "secretReminderNote": secret_reminder_note,
-          "secretMetadata": secret_metadata,
+            "workspaceId": project_id,
+            "projectSlug": project_slug,
+            "environment": environment_slug,
+            "secretPath": secret_path,
+            "secretValue": secret_value,
+            "secretComment": secret_comment,
+            "tagIds": tags_ids,
+            "skipMultilineEncoding": skip_multiline_encoding,
+            "type": "shared",
+            "secretReminderRepeatDays": secret_reminder_repeat_days,
+            "secretReminderNote": secret_reminder_note,
+            "secretMetadata": secret_metadata,
         }
 
         if project_slug is None and project_id is None:
@@ -149,23 +262,24 @@ class V3RawSecrets:
         result = self.requests.post(
             path=f"/api/v3/secrets/raw/{secret_name}",
             json=requestBody,
-            model=SingleSecretResponse
+            model=SingleSecretResponse,
         )
 
-
         if self.cache.enabled:
-          cache_params = {
-            "project_id": project_id,
-            "environment_slug": environment_slug,
-            "secret_path": secret_path,
-            "secret_name": secret_name,
-          }
+            cache_params = {
+                "project_id": project_id,
+                "environment_slug": environment_slug,
+                "secret_path": secret_path,
+                "secret_name": secret_name,
+            }
 
-          cache_key = self.cache.compute_cache_key(CACHE_KEY_SINGLE_SECRET, **cache_params)
-          self.cache.set(cache_key, result.data.secret)
+            cache_key = self.cache.compute_cache_key(
+                CACHE_KEY_SINGLE_SECRET, **cache_params
+            )
+            self.cache.set(cache_key, result.data.secret)
 
-          # Invalidates all list secret cache
-          self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
+            # Invalidates all list secret cache
+            self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
 
         return result.data.secret
 
@@ -184,22 +298,22 @@ class V3RawSecrets:
         project_slug: str = None,
         secret_metadata: Optional[List[Dict[str, Any]]] = None,
         tags_ids: Optional[List[str]] = None,
-        ) -> BaseSecret:
+    ) -> BaseSecret:
 
         requestBody = {
-          "workspaceId": project_id,
-          "projectSlug": project_slug,
-          "environment": environment_slug,
-          "secretPath": secret_path,
-          "secretValue": secret_value,
-          "secretComment": secret_comment,
-          "newSecretName": new_secret_name,
-          "tagIds": tags_ids,
-          "skipMultilineEncoding": skip_multiline_encoding,
-          "type": "shared",
-          "secretReminderRepeatDays": secret_reminder_repeat_days,
-          "secretReminderNote": secret_reminder_note,
-          "secretMetadata": secret_metadata,
+            "workspaceId": project_id,
+            "projectSlug": project_slug,
+            "environment": environment_slug,
+            "secretPath": secret_path,
+            "secretValue": secret_value,
+            "secretComment": secret_comment,
+            "newSecretName": new_secret_name,
+            "tagIds": tags_ids,
+            "skipMultilineEncoding": skip_multiline_encoding,
+            "type": "shared",
+            "secretReminderRepeatDays": secret_reminder_repeat_days,
+            "secretReminderNote": secret_reminder_note,
+            "secretMetadata": secret_metadata,
         }
 
         if project_slug is None and project_id is None:
@@ -208,62 +322,67 @@ class V3RawSecrets:
         result = self.requests.patch(
             path=f"/api/v3/secrets/raw/{current_secret_name}",
             json=requestBody,
-            model=SingleSecretResponse
+            model=SingleSecretResponse,
         )
 
         if self.cache.enabled:
-           cache_params = {
-            "project_id": project_id,
-            "environment_slug": environment_slug,
-            "secret_path": secret_path,
-            "secret_name": current_secret_name,
-           }
+            cache_params = {
+                "project_id": project_id,
+                "environment_slug": environment_slug,
+                "secret_path": secret_path,
+                "secret_name": current_secret_name,
+            }
 
-           cache_key = self.cache.compute_cache_key(CACHE_KEY_SINGLE_SECRET, **cache_params)
-           self.cache.unset(cache_key)
+            cache_key = self.cache.compute_cache_key(
+                CACHE_KEY_SINGLE_SECRET, **cache_params
+            )
+            self.cache.unset(cache_key)
 
-           # Invalidates all list secret cache
-           self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
+            # Invalidates all list secret cache
+            self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
 
         return result.data.secret
 
     def delete_secret_by_name(
-            self,
-            secret_name: str,
-            secret_path: str,
-            environment_slug: str,
-            project_id: str = None,
-            project_slug: str = None) -> BaseSecret:
+        self,
+        secret_name: str,
+        secret_path: str,
+        environment_slug: str,
+        project_id: str = None,
+        project_slug: str = None,
+    ) -> BaseSecret:
 
         if project_slug is None and project_id is None:
             raise ValueError("project_slug or project_id must be provided")
 
         requestBody = {
-          "workspaceId": project_id,
-          "projectSlug": project_slug,
-          "environment": environment_slug,
-          "secretPath": secret_path,
-          "type": "shared",
+            "workspaceId": project_id,
+            "projectSlug": project_slug,
+            "environment": environment_slug,
+            "secretPath": secret_path,
+            "type": "shared",
         }
 
         result = self.requests.delete(
             path=f"/api/v3/secrets/raw/{secret_name}",
             json=requestBody,
-            model=SingleSecretResponse
+            model=SingleSecretResponse,
         )
 
         if self.cache.enabled:
-          cache_params = {
-            "project_id": project_id,
-            "environment_slug": environment_slug,
-            "secret_path": secret_path,
-            "secret_name": secret_name,
-          }
+            cache_params = {
+                "project_id": project_id,
+                "environment_slug": environment_slug,
+                "secret_path": secret_path,
+                "secret_name": secret_name,
+            }
 
-          cache_key = self.cache.compute_cache_key(CACHE_KEY_SINGLE_SECRET, **cache_params)
-          self.cache.unset(cache_key)
+            cache_key = self.cache.compute_cache_key(
+                CACHE_KEY_SINGLE_SECRET, **cache_params
+            )
+            self.cache.unset(cache_key)
 
-          # Invalidates all list secret cache
-          self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
+            # Invalidates all list secret cache
+            self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
 
         return result.data.secret

--- a/sink/example.py
+++ b/sink/example.py
@@ -1,21 +1,23 @@
-from infisical_sdk import InfisicalSDKClient, SymmetricEncryption
-
-import random
 import base64
 import os
+import random
 import string
 
-def loadEnvVarsFromFileIntoEnv():
-  d = dict()
-  with open("./.env", "r") as fp:
-      for line in fp:
-          line = line.strip()
-          if line and not line.startswith("#"):
-            line = line.split("=", 1)
-            d[line[0]] = line[1]
+from infisical_sdk import InfisicalSDKClient, SymmetricEncryption
 
-  for key, value in d.items():
-    os.environ[key] = value
+
+def loadEnvVarsFromFileIntoEnv():
+    d = dict()
+    with open("./sink/.env", "r") as fp:
+        for line in fp:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                line = line.split("=", 1)
+                d[line[0]] = line[1]
+
+    for key, value in d.items():
+        os.environ[key] = value
+
 
 loadEnvVarsFromFileIntoEnv()
 
@@ -26,20 +28,25 @@ SECRETS_PROJECT_ID = os.getenv("SECRETS_PROJECT_ID")
 KMS_PROJECT_ID = os.getenv("KMS_PROJECT_ID")
 SECRETS_ENVIRONMENT_SLUG = os.getenv("SECRETS_ENVIRONMENT_SLUG")
 
-MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_ID = os.getenv("MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_ID")
-MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_SECRET = os.getenv("MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_SECRET")
+MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_ID = os.getenv(
+    "MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_ID"
+)
+MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_SECRET = os.getenv(
+    "MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_SECRET"
+)
 SITE_URL = os.getenv("SITE_URL")
 
 
-sdkInstance.auth.universal_auth.login(MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_ID, MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_SECRET)
+sdkInstance.auth.universal_auth.login(
+    MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_ID,
+    MACHINE_IDENTITY_UNIVERSAL_AUTH_CLIENT_SECRET,
+)
 
 
 def random_string(length: int = 10) -> str:
     # Use only lowercase letters, numbers, and hyphens
-    allowed_chars = string.ascii_lowercase + string.digits + '-'
-    return ''.join(random.choices(allowed_chars, k=length))
-
-
+    allowed_chars = string.ascii_lowercase + string.digits + "-"
+    return "".join(random.choices(allowed_chars, k=length))
 
 
 ################################################# SECRET TESTS #################################################
@@ -53,10 +60,12 @@ new_secret = sdkInstance.secrets.create_secret_by_name(
     secret_comment=f"Optional comment_{random_string()}",
     skip_multiline_encoding=False,
     secret_reminder_repeat_days=30,  # Optional
-    secret_reminder_note=f"Remember to update this secret_{random_string()}"  # Optional
+    secret_reminder_note=f"Remember to update this secret_{random_string()}",  # Optional
 )
 
-print(f"Created secret: [key={new_secret.secretKey}] | [value={new_secret.secretValue}]")
+print(
+    f"Created secret: [key={new_secret.secretKey}] | [value={new_secret.secretValue}]"
+)
 
 updated_secret = sdkInstance.secrets.update_secret_by_name(
     current_secret_name=new_secret.secretKey,
@@ -68,10 +77,12 @@ updated_secret = sdkInstance.secrets.update_secret_by_name(
     skip_multiline_encoding=False,
     secret_reminder_repeat_days=10,  # Optional
     secret_reminder_note=f"Updated reminder note_{random_string()}",  # Optional
-    new_secret_name=f"NEW_NAME_{random_string()}"  # Optional
+    new_secret_name=f"NEW_NAME_{random_string()}",  # Optional
 )
 
-print(f"Updated secret: [key={updated_secret.secretKey}] | [value={updated_secret.secretValue}]")
+print(
+    f"Updated secret: [key={updated_secret.secretKey}] | [value={updated_secret.secretValue}]"
+)
 secret = sdkInstance.secrets.get_secret_by_name(
     secret_name=updated_secret.secretKey,
     project_id=SECRETS_PROJECT_ID,
@@ -79,7 +90,7 @@ secret = sdkInstance.secrets.get_secret_by_name(
     secret_path="/",
     expand_secret_references=True,
     include_imports=True,
-    version=None  # Optional
+    version=None,  # Optional
 )
 
 print(f"Retrieved secret: [key={secret.secretKey}] | [value={secret.secretValue}]")
@@ -90,27 +101,34 @@ all_secrets = sdkInstance.secrets.list_secrets(
     environment_slug=SECRETS_ENVIRONMENT_SLUG,
     secret_path="/",
     expand_secret_references=True,
-    include_imports=True
+    include_imports=True,
+    sync_env_vars=True,
 )
 
 
-all_secrets.secrets = [secret for secret in all_secrets.secrets if secret.secretKey != "TEST"]
+all_secrets.secrets = [
+    secret for secret in all_secrets.secrets if secret.secretKey != "TEST"
+]
 if len(all_secrets.secrets) != 1:
     raise Exception("Expected 1 secret, got {}".format(len(all_secrets.secrets)))
 
 
 # Print all secret keys
 for idx, secret in enumerate(all_secrets.secrets):
-    print(f"Listed secrets key {idx}: [{secret.secretKey}] | [value={secret.secretValue}]")
+    print(
+        f"Listed secrets key {idx}: [{secret.secretKey}] | [value={secret.secretValue}]"
+    )
 
 deleted_secret = sdkInstance.secrets.delete_secret_by_name(
     secret_name=updated_secret.secretKey,
     project_id=SECRETS_PROJECT_ID,
     environment_slug=SECRETS_ENVIRONMENT_SLUG,
-    secret_path="/"
+    secret_path="/",
 )
 
-print(f"Deleted secret: [key={deleted_secret.secretKey}] | [value={deleted_secret.secretValue}]")
+print(
+    f"Deleted secret: [key={deleted_secret.secretKey}] | [value={deleted_secret.secretValue}]"
+)
 
 ################################################# KMS TESTS #################################################
 
@@ -118,7 +136,7 @@ kms_key = sdkInstance.kms.create_key(
     name=f"test-key-{random_string()}",
     project_id=KMS_PROJECT_ID,
     encryption_algorithm=SymmetricEncryption.AES_GCM_256,
-    description=f"Optional description_{random_string()}"
+    description=f"Optional description_{random_string()}",
 )
 
 print(f"Created KMS key: [key={kms_key.id}] | [name={kms_key.name}]")
@@ -128,40 +146,30 @@ plantext = "Hello, world!"
 
 encrypted = sdkInstance.kms.encrypt_data(
     key_id=kms_key.id,
-    base64EncodedPlaintext=base64.b64encode(plantext.encode()).decode()
+    base64EncodedPlaintext=base64.b64encode(plantext.encode()).decode(),
 )
 
 print(f"Encrypted: {encrypted}")
 
-decrypted = sdkInstance.kms.decrypt_data(
-    key_id=kms_key.id,
-    ciphertext=encrypted
-)
+decrypted = sdkInstance.kms.decrypt_data(key_id=kms_key.id, ciphertext=encrypted)
 
 print(f"Decrypted: {base64.b64decode(decrypted.encode()).decode()}")
 
-key_by_id = sdkInstance.kms.get_key_by_id(
-    key_id=kms_key.id
-)
+key_by_id = sdkInstance.kms.get_key_by_id(key_id=kms_key.id)
 
 print(f"Key by ID: {key_by_id}")
 
 key_by_name = sdkInstance.kms.get_key_by_name(
-    key_name=kms_key.name,
-    project_id=KMS_PROJECT_ID
+    key_name=kms_key.name, project_id=KMS_PROJECT_ID
 )
 
 print(f"Key by Name: {key_by_name}")
 
-list_keys = sdkInstance.kms.list_keys(
-    project_id=KMS_PROJECT_ID
-)
+list_keys = sdkInstance.kms.list_keys(project_id=KMS_PROJECT_ID)
 
 print(f"List keys: {list_keys}")
 
 
-deleted_key = sdkInstance.kms.delete_key(
-    key_id=kms_key.id
-)
+deleted_key = sdkInstance.kms.delete_key(key_id=kms_key.id)
 
 print(f"Deleted key: {deleted_key}")


### PR DESCRIPTION
Introduced a local synchronization feature to the list_secrets method. 
When sync_env_vars is enabled, the SDK will now:

- Fetch secrets from the Infisical API and compare them with a local .env file.
- Automatically update existing keys in the .env file with the latest values from the API.
- Append new keys that do not exist locally while preserving comments and file structure.
- Generate a persistent audit log in '.infisical-sync-report.txt' detailing all additions and updates with timestamps.
- Automatically ensure the report file is added to .gitignore to prevent accidental commits of sensitive metadata.

This enhancement improves the local developer experience by keeping environment variables in sync with the source of truth without manual intervention.

Signed-off-by: Nafees Madni <nmadni82@gmail.com>