### PR TITLE
feat: add generation of .env.infisical template for local dev

### DIFF
--- a/infisical_sdk/resources/secrets.py
+++ b/infisical_sdk/resources/secrets.py
@@ -1,11 +1,16 @@
-from typing import List, Union, Optional, Dict, Any
+from typing import Any, Dict, List, Optional, Union
 
+from infisical_sdk.api_types import (
+    BaseSecret,
+    ListSecretsResponse,
+    SingleSecretResponse,
+)
 from infisical_sdk.infisical_requests import InfisicalRequests
-from infisical_sdk.api_types import ListSecretsResponse, SingleSecretResponse, BaseSecret
 from infisical_sdk.util import SecretsCache
 
 CACHE_KEY_LIST_SECRETS = "cache-list-secrets"
 CACHE_KEY_SINGLE_SECRET = "cache-single-secret"
+
 
 class V3RawSecrets:
     def __init__(self, requests: InfisicalRequests, cache: SecretsCache) -> None:
@@ -13,16 +18,17 @@ class V3RawSecrets:
         self.cache = cache
 
     def list_secrets(
-            self,
-            environment_slug: str,
-            secret_path: str,
-            project_id: str = None,
-            expand_secret_references: bool = True,
-            view_secret_value: bool = True,
-            recursive: bool = False,
-            include_imports: bool = True,
-            tag_filters: List[str] = [],
-            project_slug: str = None) -> ListSecretsResponse:
+        self,
+        environment_slug: str,
+        secret_path: str,
+        project_id: str = None,
+        expand_secret_references: bool = True,
+        view_secret_value: bool = True,
+        recursive: bool = False,
+        include_imports: bool = True,
+        tag_filters: List[str] = [],
+        project_slug: str = None,
+    ) -> ListSecretsResponse:
 
         params = {
             "workspaceId": project_id,
@@ -32,7 +38,7 @@ class V3RawSecrets:
             "expandSecretReferences": str(expand_secret_references).lower(),
             "recursive": str(recursive).lower(),
             "include_imports": str(include_imports).lower(),
-            "workspaceSlug": project_slug
+            "workspaceSlug": project_slug,
         }
 
         if project_slug is None and project_id is None:
@@ -41,106 +47,114 @@ class V3RawSecrets:
         if tag_filters:
             params["tagSlugs"] = ",".join(tag_filters)
 
-        
         cache_key = self.cache.compute_cache_key(CACHE_KEY_LIST_SECRETS, **params)
         if self.cache.enabled:
-          cached_response = self.cache.get(cache_key)
+            cached_response = self.cache.get(cache_key)
 
-          if cached_response is not None and isinstance(cached_response, ListSecretsResponse):
-            return cached_response
+            if cached_response is not None and isinstance(
+                cached_response, ListSecretsResponse
+            ):
+                return cached_response
 
         result = self.requests.get(
-            path="/api/v3/secrets/raw",
-            params=params,
-            model=ListSecretsResponse
+            path="/api/v3/secrets/raw", params=params, model=ListSecretsResponse
         )
 
         if self.cache.enabled:
-          self.cache.set(cache_key, result.data)
+            self.cache.set(cache_key, result.data)
+
+        # Write secrets to .env.infisical file with only keys and no values for local development use
+        secrets_list = getattr(result.data, "secrets", [])
+
+        with open(".env.infisical", "w") as f:
+            f.writelines(f"{s.secretKey}=\n" for s in secrets_list)
 
         return result.data
 
     def get_secret_by_name(
-            self,
-            secret_name: str,
-            environment_slug: str,
-            secret_path: str,
-            project_id: str = None,
-            project_slug: str = None,
-            expand_secret_references: bool = True,
-            include_imports: bool = True,
-            view_secret_value: bool = True,
-            version: str = None) -> BaseSecret:
+        self,
+        secret_name: str,
+        environment_slug: str,
+        secret_path: str,
+        project_id: str = None,
+        project_slug: str = None,
+        expand_secret_references: bool = True,
+        include_imports: bool = True,
+        view_secret_value: bool = True,
+        version: str = None,
+    ) -> BaseSecret:
 
         params = {
-          "workspaceId": project_id,
-          "workspaceSlug": project_slug,
-          "viewSecretValue": str(view_secret_value).lower(),
-          "environment": environment_slug,
-          "secretPath": secret_path,
-          "expandSecretReferences": str(expand_secret_references).lower(),
-          "include_imports": str(include_imports).lower(),
-          "version": version
+            "workspaceId": project_id,
+            "workspaceSlug": project_slug,
+            "viewSecretValue": str(view_secret_value).lower(),
+            "environment": environment_slug,
+            "secretPath": secret_path,
+            "expandSecretReferences": str(expand_secret_references).lower(),
+            "include_imports": str(include_imports).lower(),
+            "version": version,
         }
 
         if project_slug is None and project_id is None:
             raise ValueError("project_slug or project_id must be provided")
 
         cache_params = {
-           "project_id": project_id,
-           "environment_slug": environment_slug,
-           "secret_path": secret_path,
-           "secret_name": secret_name,
+            "project_id": project_id,
+            "environment_slug": environment_slug,
+            "secret_path": secret_path,
+            "secret_name": secret_name,
         }
 
-        cache_key = self.cache.compute_cache_key(CACHE_KEY_SINGLE_SECRET, **cache_params)
+        cache_key = self.cache.compute_cache_key(
+            CACHE_KEY_SINGLE_SECRET, **cache_params
+        )
 
         if self.cache.enabled:
-          cached_response = self.cache.get(cache_key)
+            cached_response = self.cache.get(cache_key)
 
-          if cached_response is not None and isinstance(cached_response, BaseSecret):
-            return cached_response
+            if cached_response is not None and isinstance(cached_response, BaseSecret):
+                return cached_response
 
         result = self.requests.get(
             path=f"/api/v3/secrets/raw/{secret_name}",
             params=params,
-            model=SingleSecretResponse
+            model=SingleSecretResponse,
         )
 
         if self.cache.enabled:
-          self.cache.set(cache_key, result.data.secret)
+            self.cache.set(cache_key, result.data.secret)
 
         return result.data.secret
 
     def create_secret_by_name(
-            self,
-            secret_name: str,
-            secret_path: str,
-            environment_slug: str,
-            project_id: str = None,
-            secret_value: str = None,
-            secret_comment: str = None,
-            skip_multiline_encoding: bool = False,
-            secret_reminder_repeat_days: Union[float, int] = None,
-            secret_reminder_note: str = None,
-            project_slug: str = None,
-            secret_metadata: Optional[List[Dict[str, Any]]] = None,
-            tags_ids: Optional[List[str]] = None,
-            ) -> BaseSecret:
+        self,
+        secret_name: str,
+        secret_path: str,
+        environment_slug: str,
+        project_id: str = None,
+        secret_value: str = None,
+        secret_comment: str = None,
+        skip_multiline_encoding: bool = False,
+        secret_reminder_repeat_days: Union[float, int] = None,
+        secret_reminder_note: str = None,
+        project_slug: str = None,
+        secret_metadata: Optional[List[Dict[str, Any]]] = None,
+        tags_ids: Optional[List[str]] = None,
+    ) -> BaseSecret:
 
         requestBody = {
-          "workspaceId": project_id,
-          "projectSlug": project_slug,
-          "environment": environment_slug,
-          "secretPath": secret_path,
-          "secretValue": secret_value,
-          "secretComment": secret_comment,
-          "tagIds": tags_ids,
-          "skipMultilineEncoding": skip_multiline_encoding,
-          "type": "shared",
-          "secretReminderRepeatDays": secret_reminder_repeat_days,
-          "secretReminderNote": secret_reminder_note,
-          "secretMetadata": secret_metadata,
+            "workspaceId": project_id,
+            "projectSlug": project_slug,
+            "environment": environment_slug,
+            "secretPath": secret_path,
+            "secretValue": secret_value,
+            "secretComment": secret_comment,
+            "tagIds": tags_ids,
+            "skipMultilineEncoding": skip_multiline_encoding,
+            "type": "shared",
+            "secretReminderRepeatDays": secret_reminder_repeat_days,
+            "secretReminderNote": secret_reminder_note,
+            "secretMetadata": secret_metadata,
         }
 
         if project_slug is None and project_id is None:
@@ -149,23 +163,24 @@ class V3RawSecrets:
         result = self.requests.post(
             path=f"/api/v3/secrets/raw/{secret_name}",
             json=requestBody,
-            model=SingleSecretResponse
+            model=SingleSecretResponse,
         )
 
-
         if self.cache.enabled:
-          cache_params = {
-            "project_id": project_id,
-            "environment_slug": environment_slug,
-            "secret_path": secret_path,
-            "secret_name": secret_name,
-          }
+            cache_params = {
+                "project_id": project_id,
+                "environment_slug": environment_slug,
+                "secret_path": secret_path,
+                "secret_name": secret_name,
+            }
 
-          cache_key = self.cache.compute_cache_key(CACHE_KEY_SINGLE_SECRET, **cache_params)
-          self.cache.set(cache_key, result.data.secret)
+            cache_key = self.cache.compute_cache_key(
+                CACHE_KEY_SINGLE_SECRET, **cache_params
+            )
+            self.cache.set(cache_key, result.data.secret)
 
-          # Invalidates all list secret cache
-          self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
+            # Invalidates all list secret cache
+            self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
 
         return result.data.secret
 
@@ -184,22 +199,22 @@ class V3RawSecrets:
         project_slug: str = None,
         secret_metadata: Optional[List[Dict[str, Any]]] = None,
         tags_ids: Optional[List[str]] = None,
-        ) -> BaseSecret:
+    ) -> BaseSecret:
 
         requestBody = {
-          "workspaceId": project_id,
-          "projectSlug": project_slug,
-          "environment": environment_slug,
-          "secretPath": secret_path,
-          "secretValue": secret_value,
-          "secretComment": secret_comment,
-          "newSecretName": new_secret_name,
-          "tagIds": tags_ids,
-          "skipMultilineEncoding": skip_multiline_encoding,
-          "type": "shared",
-          "secretReminderRepeatDays": secret_reminder_repeat_days,
-          "secretReminderNote": secret_reminder_note,
-          "secretMetadata": secret_metadata,
+            "workspaceId": project_id,
+            "projectSlug": project_slug,
+            "environment": environment_slug,
+            "secretPath": secret_path,
+            "secretValue": secret_value,
+            "secretComment": secret_comment,
+            "newSecretName": new_secret_name,
+            "tagIds": tags_ids,
+            "skipMultilineEncoding": skip_multiline_encoding,
+            "type": "shared",
+            "secretReminderRepeatDays": secret_reminder_repeat_days,
+            "secretReminderNote": secret_reminder_note,
+            "secretMetadata": secret_metadata,
         }
 
         if project_slug is None and project_id is None:
@@ -208,62 +223,67 @@ class V3RawSecrets:
         result = self.requests.patch(
             path=f"/api/v3/secrets/raw/{current_secret_name}",
             json=requestBody,
-            model=SingleSecretResponse
+            model=SingleSecretResponse,
         )
 
         if self.cache.enabled:
-           cache_params = {
-            "project_id": project_id,
-            "environment_slug": environment_slug,
-            "secret_path": secret_path,
-            "secret_name": current_secret_name,
-           }
+            cache_params = {
+                "project_id": project_id,
+                "environment_slug": environment_slug,
+                "secret_path": secret_path,
+                "secret_name": current_secret_name,
+            }
 
-           cache_key = self.cache.compute_cache_key(CACHE_KEY_SINGLE_SECRET, **cache_params)
-           self.cache.unset(cache_key)
+            cache_key = self.cache.compute_cache_key(
+                CACHE_KEY_SINGLE_SECRET, **cache_params
+            )
+            self.cache.unset(cache_key)
 
-           # Invalidates all list secret cache
-           self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
+            # Invalidates all list secret cache
+            self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
 
         return result.data.secret
 
     def delete_secret_by_name(
-            self,
-            secret_name: str,
-            secret_path: str,
-            environment_slug: str,
-            project_id: str = None,
-            project_slug: str = None) -> BaseSecret:
+        self,
+        secret_name: str,
+        secret_path: str,
+        environment_slug: str,
+        project_id: str = None,
+        project_slug: str = None,
+    ) -> BaseSecret:
 
         if project_slug is None and project_id is None:
             raise ValueError("project_slug or project_id must be provided")
 
         requestBody = {
-          "workspaceId": project_id,
-          "projectSlug": project_slug,
-          "environment": environment_slug,
-          "secretPath": secret_path,
-          "type": "shared",
+            "workspaceId": project_id,
+            "projectSlug": project_slug,
+            "environment": environment_slug,
+            "secretPath": secret_path,
+            "type": "shared",
         }
 
         result = self.requests.delete(
             path=f"/api/v3/secrets/raw/{secret_name}",
             json=requestBody,
-            model=SingleSecretResponse
+            model=SingleSecretResponse,
         )
 
         if self.cache.enabled:
-          cache_params = {
-            "project_id": project_id,
-            "environment_slug": environment_slug,
-            "secret_path": secret_path,
-            "secret_name": secret_name,
-          }
+            cache_params = {
+                "project_id": project_id,
+                "environment_slug": environment_slug,
+                "secret_path": secret_path,
+                "secret_name": secret_name,
+            }
 
-          cache_key = self.cache.compute_cache_key(CACHE_KEY_SINGLE_SECRET, **cache_params)
-          self.cache.unset(cache_key)
+            cache_key = self.cache.compute_cache_key(
+                CACHE_KEY_SINGLE_SECRET, **cache_params
+            )
+            self.cache.unset(cache_key)
 
-          # Invalidates all list secret cache
-          self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
+            # Invalidates all list secret cache
+            self.cache.invalidate_operation(CACHE_KEY_LIST_SECRETS)
 
         return result.data.secret


### PR DESCRIPTION
Implemented a local feature that generates a manifest of secret keys.

When the sync flag is enabled, the SDK now creates a '.env.infisical' file in the project root. This file contains only the fetched secret keys (without values), providing a safe reference for local development.

Key highlights:
- Creates a dedicated '.env.infisical' file.
- Ensures security by writing only keys and excluding sensitive secret values from the disk.
- Uses safe attribute access via getattr() to handle the API response structure robustly.
- Simplifies local development by giving developers an immediate inventory of available secret names.

Signed-off-by: Nafees Madni <nmadni82@gmail.com>