### PR TITLE
feat(auth): add LdapAuth class for LDAP-based authentication

### DIFF
--- a/infisical_sdk/resources/auth.py
+++ b/infisical_sdk/resources/auth.py
@@ -3,6 +3,7 @@ from infisical_sdk.resources.auth_methods import AWSAuth
 from infisical_sdk.resources.auth_methods import UniversalAuth
 from infisical_sdk.resources.auth_methods import OidcAuth
 from infisical_sdk.resources.auth_methods import TokenAuth
+from infisical_sdk.resources.auth_methods import LdapAuth
 from typing import Callable
 
 class Auth:
@@ -12,3 +13,4 @@ class Auth:
         self.universal_auth = UniversalAuth(requests, setToken)
         self.oidc_auth = OidcAuth(requests, setToken)
         self.token_auth = TokenAuth(setToken)
+        self.ldap_auth = LdapAuth(requests, setToken)

--- a/infisical_sdk/resources/auth_methods/__init__.py
+++ b/infisical_sdk/resources/auth_methods/__init__.py
@@ -2,3 +2,4 @@ from .aws_auth import AWSAuth
 from .universal_auth import UniversalAuth
 from .oidc_auth import OidcAuth
 from .token_auth import TokenAuth
+from .ldap_auth import LdapAuth

--- a/infisical_sdk/resources/auth_methods/ldap_auth.py
+++ b/infisical_sdk/resources/auth_methods/ldap_auth.py
@@ -1,0 +1,38 @@
+from infisical_sdk.api_types import MachineIdentityLoginResponse
+
+from typing import Callable
+from infisical_sdk.infisical_requests import InfisicalRequests
+
+class LdapAuth:
+    def __init__(self, requests: InfisicalRequests, setToken: Callable[[str], None]):
+        self.requests = requests
+        self.setToken = setToken
+
+    def login(self, identity_id: str, username: str, password: str) -> MachineIdentityLoginResponse:
+        """
+        Login with LDAP Auth.
+
+        Args:
+            identity_id (str): Your Machine Identity ID.
+            username (str): Your LDAP username.
+            password (str): Your LDAP password.
+
+        Returns:
+            MachineIdentityLoginResponse: A response containing the access token and related information.
+        """
+
+        requestBody = {
+            "identityId": identity_id,
+            "username": username,
+            "password": password
+        }
+
+        result = self.requests.post(
+            path="/api/v1/auth/ldap-auth/login",
+            json=requestBody,
+            model=MachineIdentityLoginResponse
+        )
+
+        self.setToken(result.data.accessToken)
+
+        return result.data


### PR DESCRIPTION
## Add LDAP Authentication Support

Adds LDAP authentication method for machine identities, bringing Python SDK to feature parity with the Go SDK.

### Changes
- Added `LdapAuth` class in `infisical_sdk/resources/auth_methods/ldap_auth.py`
- Registered LDAP auth in the `Auth` class

### Usage
```python
client = InfisicalSDKClient(host="http://localhost:8080")
result = client.auth.ldap_auth.login(
    identity_id="your-identity-id",
    username="ldap-username",
    password="ldap-password"
)
```